### PR TITLE
Update PSVault.psm1

### DIFF
--- a/PSVault/1.0.1/PSVault.psm1
+++ b/PSVault/1.0.1/PSVault.psm1
@@ -1535,7 +1535,7 @@ Function start-VaultInit               {
                 #Check Status
                 if($VaultObject){
                     $uri  = $VaultObject.uri + "/v1/sys/init"
-                }elseif($apiaddres){
+                }elseif($apiaddress){
                     $uri  = $apiaddress + "/v1/sys/init" 
                 }else{
                     $uri  =  "http://127.0.0.1:8200/v1/sys/init"   
@@ -1790,7 +1790,7 @@ function start-VaultautoUnseal         {
         [string]$AESKeyFileHash = "$VaultPath\config\AESTokenHash.txt" 
           
     )
-    
+    $keys = Import-Clixml -Path $UnsealKeyXML
     #Check Unseal
     $i=1
     do{


### PR DESCRIPTION
there was bug in the PS script on two places
1. in the start-VaultInit function, provided apiAddress was ignored because of typo
2. in start-VaultautoUnseal function, the keys were not read from the XML file. script was trying to iterate through null list